### PR TITLE
Use previous grade after max attempts

### DIFF
--- a/src/gspack/environment.py
+++ b/src/gspack/environment.py
@@ -147,6 +147,7 @@ class Environment:
         if self.attempt_number > self.max_number_of_attempts > 0 and not self.test_student:
             results["output"] = f"You've already used all {self.max_number_of_attempts} attempts.\n"
             results["tests"] = []
+            results["score"] = self.max_previous_score
 
         if keep_maximal_score:
             # Let student know if the system kept his previous maximal score


### PR DESCRIPTION
@amathsys

This should fix the issue where attempts beyond the maximum number are still graded.  The write_down_and_exit function checked to see if the maximum number of attempts had been exceeded and sent an appropriate message, but never actually updated the score.